### PR TITLE
Update to NATS CLI v0.0.31

### DIFF
--- a/synadia-nats-channels.conf
+++ b/synadia-nats-channels.conf
@@ -6,7 +6,7 @@ TOOLS=nats nsc
 
 # The nightly channel is special-cased and does not have version numbers here.
 # For the others, the version number is the git tag
-VERSION_stable_nats=v0.0.28
+VERSION_stable_nats=v0.0.31
 VERSION_stable_nsc=2.6.1
 
 # ----- END OF ROUTINE EDITS -----


### PR DESCRIPTION
Update install.sh channel to latest release version of NATS CLI v0.0.31 which is the NGSv2 launch version.