### PR TITLE
YAML engineering: quote go version string

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,7 +34,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          # This should be quoted or use .x, but should not be unquoted.
+          # Remember that a YAML bare float drops trailing zeroes.
+          go-version: '1.19'
           check-latest: true
 
       - name: Install GoReleaser


### PR DESCRIPTION
We're currently using Go 1.19; we'll switch to 1.20 when the NATS Maintainers
make the call to switch.
Prepare by making sure that `1.20` won't turn into `1.2` instead.
