### PR TITLE
zsh tab completion updates & refinements

### DIFF
--- a/zsh.complete.nats
+++ b/zsh.complete.nats
@@ -21,11 +21,14 @@
 # mapfile technique which lets us keep this as only being 'verbose'.
 #
 
-local curcontext="$curcontext" state line expl cmdword
+local curcontext="$curcontext" state line expl
 local nctx
-local -a nats_contexts nats_commands nats_sub nats_flags described_contexts
+local -a nats_contexts nats_commands nats_sub nats_flags nats_global_flags described_contexts
 local -A nats_decorate_flags_desc nats_decorate_flags_next nats_decorate_flags_mutex
-local -i nats_verbose=0
+local -i nats_verbose=0 NORMARG
+
+# We use ${mapfile[...]} for loading in the context files
+zmodload -i zsh/mapfile
 
 # extra-verbose is documented as for features which will slow completion speed.
 # verbose is just for being more wordy.
@@ -41,6 +44,7 @@ if zstyle -T ":completion:${curcontext}:" verbose; then
 fi
 
 local -ra want_context=(
+  context:copy
   context:edit
   context:info
   context:rm
@@ -85,6 +89,90 @@ case "$service" in
     ;;
 esac
 
+(( ${+functions[_nats_subcommands]} )) ||
+_nats_subcommands() {
+  local -a nats_subcommands
+  local cline copt
+  local -i should_decorate_flags=0
+  # Beware: if we're not careful, `nats s<tab>` won't distinguish that `s` is
+  # not a complete word yet and instead take it as the alias 's' for stream,
+  # find the stream sub-commands, and then filter to only the ones in that
+  # which start 's'.
+  cline="${line%%[[:space:]]##}"
+  copt=''
+  if [[ "${cline##*[[:space:]]}" == --* ]]; then
+    # it's an option
+    copt=' --'
+    should_decorate_flags=1
+  elif [[ "${cline##*[[:space:]]}" == -* ]]; then
+    copt=' -'
+  fi
+  if [[ "$cline" == "$line" ]]; then
+    if [[ "${cline%%[[:space:]]*}" == "$cline" ]]; then
+      # first word, drop it entirely
+      cline=''
+    else
+      # drop last word
+      cline="${line%%[[:space:]]##[^[:space:]]##}"
+    fi
+  fi
+  local curcontext="${curcontext%:*:*}:nats${cline:+-}${cline//[[:space:]]##/-}:"
+  nats_subcommands=( $(_call_program nats-completion-bash "${(q)words[1]} --completion-bash ${cline}${copt}") )
+  if (( should_decorate_flags )); then
+    local -a nats_flags=("${nats_subcommands[@]}")
+    _nats_decorate_flags
+    words[$NORMARG,$CURRENT-1]=()
+    CURRENT=$((NORMARG+1))
+    _arguments : "${nats_flags[@]}"
+  else
+    local full_sub="${cline//[[:space:]]##/:}"
+    if (( ${want_context[(Ie)$full_sub]} )); then
+      _nats_context_names
+    else
+      _describe -t nats-commands 'nats commands' nats_subcommands
+    fi
+  fi
+  return 0
+}
+
+(( ${+functions[_nats_decorate_flags]} )) ||
+_nats_decorate_flags() {
+  local fullflag flag directive message
+  local -a new_flags=() items expanded
+  local -a specific_flags=() global_flags=() items expanded
+  for fullflag in "${nats_flags[@]}"; do
+    flag="${fullflag#--}"
+    if (( nats_global_flags[(I)$fullflag] )); then
+      message='global flag'
+    else
+      message='sub-command flag'
+    fi
+    if (( ${+nats_decorate_flags_desc[$flag]} )); then
+      directive=''
+      if ! (( $+nats_decorate_flags_mutex[$flag] )); then
+        directive="--$flag"
+        if (( $+nats_decorate_flags_next[$flag] )); then
+          directive+="="
+        fi
+      fi
+      directive+="[${nats_decorate_flags_desc[$flag]}]:${message}"
+      if (( $+nats_decorate_flags_next[$flag] )); then
+        directive+=":${nats_decorate_flags_next[$flag]}"
+      fi
+      if (( $+nats_decorate_flags_mutex[$flag] )); then
+        # This is safe because flag is validated to be known
+        eval "expanded=(${nats_decorate_flags_mutex[$flag]})"
+        new_flags+=( ${^expanded}"$directive" )
+      else
+        new_flags+=( "$directive" )
+      fi
+    else
+      new_flags+=( "$fullflag" )
+    fi
+  done
+  nats_flags=( "${new_flags[@]}" )
+}
+
 nats_decorate_flags_desc=( # this assumes zsh is-at-least 5.5
 	[help]='show help and exit'
 	[version]='show version and exit'
@@ -112,9 +200,30 @@ nats_decorate_flags_desc=( # this assumes zsh is-at-least 5.5
 	[js-domain]='JetStream Domain (for transiting other NATS clusters)'
 	[js-event-prefix]='JetStream Advisories subject prefix'
 
+	# Here we have to be careful about phrasing when a flag might apply to
+	# different nouns in different sub-commands; it's better to skip our
+	# verbose help than to be wrong, so if in doubt, exclude.
+	#
+	# We do set curcontext appropriately so in theory we could move these
+	# into another array and take the 4th field from $curcontext and use
+	# that as a key prefix, but so far it's not worth it.
+	# We'd rather put the effort into replacing the CLI's completion support
+	# to let us remove all this specialist knowledge from the zsh wrapper.
+
 	# common sub-command flags
 	[yaml]='Produce YAML format output'
 	[json]='Produce JSON format output'
+	[force]='Proceed without prompting'
+	[subject]='NATS Subject to restrict to'
+	[top]='Show this many results'
+	[sort]='Sort on this field (see help)'
+
+	# account backup
+	[critical-warnings]='Treat warnings as failures'
+	# account tls
+	[expire-warn]='Warn about certs expiring this soon'
+	[ocsp]='Report OCSP information, if any'
+	[no-pem]='Skip showing certificate in PEM form'  # will not match if completion suggests only --pem
 )
 nats_decorate_flags_mutex=(
 	[server]='"(--server -s)"{-s,--server=}'
@@ -131,75 +240,26 @@ nats_decorate_flags_next=(
 	[js-api-prefix]=' ' [js-domain]=' ' [js-event-prefix]=' '
 	[context]='_nats_context_names'
 	[socks-proxy]='_urls'
+
+	[expire-warn]=' '  # duration
+	[subject]=' '
+	[sort]='_message -r sort order' # different keywords in different contexts
+	[top]='_message -r numeric count'
 )
 
 # We populate a complete set first, so that even if we don't have more details below,
 # we can still tab-complete it; it will just be missing some data
-nats_commands=( $(_call_program nats-completion-bash "${(q)words[1]} --completion-bash ${(qq)words[1]}") )
-
+#
 # Most flags can appear anywhere; this is not a git-style "top command flags"
 # vs "subcommand flags", but instead "one pool of flags which gains extra
 # entries for some subcommands".
-nats_flags=( $(_call_program nats-completion-bash "${(q)words[1]} --completion-bash ${(qq)words[1]} --") )
-
-(( ${+functions[_nats_decorate_flags]} )) ||
-_nats_decorate_flags() {
-  #zle -M "decorating ..."; zle -R
-  local flag directive
-  local -a expanded
-  for flag in "${(@k)nats_decorate_flags_desc}"; do
-    (( nats_flags[(I)--$flag] )) || continue
-    directive=''
-    if ! (( $+nats_decorate_flags_mutex[$flag] )); then
-      directive="--$flag"
-      if (( $+nats_decorate_flags_next[$flag] )); then
-        directive+="="
-      fi
-    fi
-    directive+="[${nats_decorate_flags_desc[$flag]}]:${nats_decorate_flags_desc[$flag]}"
-    if (( $+nats_decorate_flags_next[$flag] )); then
-      directive+=":${nats_decorate_flags_next[$flag]}"
-    fi
-    if (( $+nats_decorate_flags_mutex[$flag] )); then
-      # This is safe because _we_ control all inputs to the eval, nothing comes from the command
-      eval "expanded=(${nats_decorate_flags_mutex[$flag]})"
-      nats_flags[(I)--$flag]=(${^expanded}"$directive")
-    else
-      nats_flags[(I)--$flag]="$directive"
-    fi
-  done
-}
-
+#
+nats_global_flags=( $(_call_program nats-completion-bash "${(q)words[1]} --completion-bash ${line} --") )
+nats_flags=("${nats_global_flags[@]}")
 _nats_decorate_flags
 
-cmdword="${words[1]}"
-
-_arguments -C \
-  "${nats_flags[@]}" \
-  '(-): :->commands' \
-  '(-)*:: :->after-command' && return
+_arguments -n -A '-*' -C : "${nats_flags[@]}" '(-)*: :->subcommands' && return
 
 case "$state" in
-(commands)
-  _describe -t nats-commands 'nats commands' nats_commands
-  return
-  ;;
-(after-command)
-  curcontext=${curcontext%:*:*}:nats-$words[1]:
-  nats_sub=( $(_call_program nats-completion-bash "${(q)cmdword} --completion-bash ${${(qq)words[@]}}") )
-  if [[ ${#nats_sub} -eq 0 ]]; then
-    # terminal
-    nats_flags=( $(_call_program nats-completion-bash "${(q)cmdwords} --completion-bash ${${(qq)words[@]}} --") )
-    _nats_decorate_flags
-    # We use -2 to drop the last word, which might be mid-word if expanding again after a few letters.
-    nctx="${(j,:,)words[1,-2]}"
-    if (( ${want_context[(Ie)$nctx]} )); then
-      _arguments -C "${nats_flags[@]}" '(-): :->commands' '(-)*:: :_nats_context_names' && return
-    else
-      _arguments -C "${nats_flags[@]}" '(-): :->commands' '(-)*:: :->after-command' && return
-    fi
-  else
-    _describe -t nats-sub-commands 'nats sub-commands' nats_sub
-  fi
-  ;;
+  (subcommands) _nats_subcommands ;;
 esac


### PR DESCRIPTION
* Load `zsh/mapfile` if not already loaded, to avoid zsh complaining about confusing math errors
* Some tab-completion for command-specific flags, including flags _after_ words
* Various fixes to sub-commands handling, via a revamp

I've been using the structural changes for 6 months in my .personal repo, so by this point they're battle-hardened.