### PR TITLE
nightlies building: use Go 1.22 and goreleaser v1

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           # This should be quoted or use .x, but should not be unquoted.
           # Remember that a YAML bare float drops trailing zeroes.
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
           # As of v3 of this action, we could also use `go-version-file: # go.mod`
           # and get the version from there, but that is semantically wrong: the
@@ -47,10 +47,14 @@ jobs:
 
       - name: Install GoReleaser
         id: goreleaser-install
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          # 2024-06-05: goreleaser v2 is out, and makes deprecations fatal.
+          # Our build-nightlies.sh invokes goreleaser in the repos for the nsc
+          # and natscli tools, so we can't update until both of those are
+          # deprecation-free under v1.26.2
+          version: "~> v1"
           install-only: true
 
       - name: Install cosign


### PR DESCRIPTION
Bump from Go 1.21 to 1.22.

Latch goreleaser-pro back to v1, as we need to wait for other repos to update their `.goreleaser.yaml` files to be clean of deprecation warnings.