### PR TITLE
Switch to pinning GH Actions; bump stale deps

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # NB: the `fetch-depth: 0` setting is documented by goreleaser
           # as a requirement, for the changelog feature to work correctly.
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
           # v5 over v4 updates the Node runtime from node16 to node20.
         with:
           # This should be quoted or use .x, but should not be unquoted.
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install GoReleaser
         id: goreleaser-install
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           distribution: goreleaser-pro
           version: "~> v2"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install cosign
         id: cosign-install
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       # As of actions/setup-go@v4, go modules and build outputs are cached by default.
       # Prior to the update to use that, we used actions/cache@v3 here for a step:
@@ -109,7 +109,7 @@ jobs:
     needs: [nightly_release]
     steps:
       - name: Notify Synadia Communications Slack
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SYNADIA_BUILDS_GITHUB }}
           SLACK_USERNAME: "client-tools-nightlies-builder"

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -29,13 +29,13 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # We don't need to work with the git remote after this, so:
           persist-credentials: false
 
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f # v1.1
         with:
           # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
           # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
@@ -47,6 +47,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
* **GitHub Actions: nightly: pin actions**
  + Switches the cosign installer away from `main`, which was a legacy of being a rather early user of that action.
  + Pin all Actions using the de-facto standard format
* **GitHub Actions: powershell: pin and bump**
  + Pin the actions which weren't already pinned
    - And decorate in the normal style the one which was
  + Switch `github/codeql-action/upload-sarif` from v2 to v3
    - v2 is deprecated and may stop working without notice.
